### PR TITLE
Bugfix history frontend

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path').join(__dirname, '../client/dist/');
+const history = require('connect-history-api-fallback');
 
 const app = express();
 const corsOptions = {
   origin: 'http://localhost:8080',
 };
 
-app.use(express.static(path));
 app.use(cors(corsOptions));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
@@ -15,5 +15,13 @@ app.use(express.json());
 app.use('/api', require('./routes/shoutoutRoutes'));
 app.use('/api', require('./routes/valuesRoutes'));
 app.use('/api', require('./routes/slackRoutes'));
+
+app.use(
+  history({
+    verbose: true,
+  }),
+);
+
+app.use('/', express.static(path));
 
 module.exports = app;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -509,6 +509,11 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",
+    "connect-history-api-fallback": "^1.6.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
### Type of change:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling - no new features

### Why is this change required? What problem(s) does it solve?
This PR allows the user to refresh the page and not receive an error. Before, we were getting an error where the user would go to the homepage, navigate to one of the frontend routes (i.e. from `localhost:8081/` to `localhost:8081/reports`), click refresh and get an error and a broken page. The browser would make a `GET` request to `localhost:8081/reports` which would result in a bad request. We implemented the `connect-history-api-fallback` middleware to fix this problem
### Were there any challenges while implementing this feature? If so, how were they addressed?
N/A
### Where should the reviewer start? How can this be tested?
The user can start up the server, navigate to a frontend route and click refresh.
### Link issues
Closes #10 